### PR TITLE
Fix compile warnings

### DIFF
--- a/a18.c
+++ b/a18.c
@@ -433,13 +433,13 @@ static void normal_op(void)
                     error('R');
                     return;
                 }
-
+                /*FALLTHROUGH*/
             case NOT_R0:
                 if (!operand) {
                     error('R');
                     return;
                 }
-
+                /*FALLTHROUGH*/
             case ANY:
                 if (operand > 15) {
                     error('R');

--- a/a18.c
+++ b/a18.c
@@ -72,13 +72,13 @@ parse the source line convert it into the object bytes that it represents.
 
 /*  Local prototypes:                                                   */
 
-void asm_line(void);
-void do_label(void);
-unsigned *do_string(char *s, unsigned *o);
-void flush(void);
-int isoct(char c);
-void normal_op(void);
-void pseudo_op(void);
+static void asm_line(void);
+static void do_label(void);
+static unsigned *do_string(char *s, unsigned *o);
+static void flush(void);
+static int isoct(char c);
+static void normal_op(void);
+static void pseudo_op(void);
 
 /*  Define global mailboxes for all modules:                            */
 
@@ -294,7 +294,7 @@ int ifstack[IFDEPTH] = { ON };
 
 OPCODE *opcod;
 
-void asm_line(void)
+static void asm_line(void)
 {
     SCRATCH int i;
     SCRATCH size_t len;
@@ -371,12 +371,12 @@ void asm_line(void)
     return;
 }
 
-void flush(void)
+static void flush(void)
 {
     while (popc() != '\n');
 }
 
-void do_label(void)
+static void do_label(void)
 {
     SCRATCH SYMBOL *l;
     SCRATCH size_t len;
@@ -407,7 +407,7 @@ void do_label(void)
     }
 }
 
-void normal_op(void)
+static void normal_op(void)
 {
     SCRATCH unsigned attrib, *objp, operand;
 
@@ -477,7 +477,7 @@ void normal_op(void)
     }
 }
 
-unsigned *do_string(char *s, unsigned *o)
+static unsigned *do_string(char *s, unsigned *o)
 {
     SCRATCH int esc;
     SCRATCH char t;
@@ -544,7 +544,7 @@ unsigned *do_string(char *s, unsigned *o)
     return o;
 }
 
-void pseudo_op(void)
+static void pseudo_op(void)
 {
     SCRATCH unsigned *o, u, v;
     SCRATCH SYMBOL *l;
@@ -1490,7 +1490,7 @@ void pseudo_op(void)
     return;
 }
 
-int isoct(char c)
+static int isoct(char c)
 {
     return c >= '0' && c <= '7';
 }

--- a/a18.c
+++ b/a18.c
@@ -129,9 +129,7 @@ PREDEFINED predef[] = {
 
 int npredef = sizeof(predef) / sizeof(PREDEFINED);
 
-void main(argc,argv)
-int argc;
-char **argv;
+int main(int argc, char **argv)
 {
     SCRATCH unsigned *o;
     SCRATCH int i;
@@ -401,7 +399,8 @@ void do_label()
             }
         }
         else {
-            if (l = find_symbol(label, TRUE)) {
+            l = find_symbol(label, TRUE);
+            if (l != NULL) {
                 l -> attr = VAL;
                 if (l -> valu != pc)
                     error('M');
@@ -728,7 +727,8 @@ void pseudo_op()
                     }
                 }
                 else {
-                    if (l = find_symbol(label, FALSE)) {
+                    l = find_symbol(label, FALSE);
+                    if (l != NULL) {
                         l -> attr = VAL;
                         address = expr();
                         if (forwd)
@@ -849,7 +849,8 @@ void pseudo_op()
                     }
                 }
                 else {
-                    if (l = find_symbol(label, FALSE)) {
+                    l = find_symbol(label, FALSE);
+                    if (l != NULL) {
                         address = expr();
                         if (forwd)
                             error('P');
@@ -872,7 +873,8 @@ void pseudo_op()
             if (pass == 2) {
                 while ((lex()->attr & TYPE) != EOL) {
                     if ((token.attr & TYPE) == VAL) {
-                        if (l = find_symbol(token.sval, FALSE)) {
+                        l = find_symbol(token.sval, FALSE);
+                        if (l != NULL) {
                             l->shared = TRUE;
                         }
                         else

--- a/a18.c
+++ b/a18.c
@@ -70,6 +70,16 @@ parse the source line convert it into the object bytes that it represents.
 
 #include "a18.h"
 
+/*  Local prototypes:                                                   */
+
+void asm_line(void);
+void do_label(void);
+unsigned *do_string(char *s, unsigned *o);
+void flush(void);
+int isoct(char c);
+void normal_op(void);
+void pseudo_op(void);
+
 /*  Define global mailboxes for all modules:                            */
 
 char errcode, line[MAXLINE + 1], title[MAXLINE];
@@ -134,14 +144,6 @@ int main(int argc, char **argv)
     SCRATCH unsigned *o;
     SCRATCH int i;
     SCRATCH SYMBOL* l;
-    SYMBOL* new_symbol();
-    int newline();
-    void asm_line();
-    void lclose(), lopen(), lputs();
-    void hclose(), hopen(), hputc();
-    void rclose(), ropen(), rputc();
-    void sclose(), sopen();
-    void fatal_error(), warning();
 
     printf("1802/1805A Cross-Assembler (Portable) Ver 3.0\n");
     printf("Copyright (c) 1985 William C. Colley, III\n");
@@ -292,14 +294,10 @@ int ifstack[IFDEPTH] = { ON };
 
 OPCODE *opcod;
 
-void asm_line()
+void asm_line(void)
 {
     SCRATCH int i;
     SCRATCH size_t len;
-    int isalph(), popc();
-    OPCODE *find_code(), *find_operator();
-    void do_label(), flush(), normal_op(), pseudo_op();
-    void pops(), pushc(), trash();
 
     address = pc;
     bytes = 0;
@@ -373,17 +371,15 @@ void asm_line()
     return;
 }
 
-void flush()
+void flush(void)
 {
     while (popc() != '\n');
 }
 
-void do_label()
+void do_label(void)
 {
     SCRATCH SYMBOL *l;
     SCRATCH size_t len;
-    SYMBOL *find_symbol(), *new_symbol();
-//    void error();
 
     if (label[0]) {
         listhex = TRUE;
@@ -411,12 +407,9 @@ void do_label()
     }
 }
 
-void normal_op()
+void normal_op(void)
 {
     SCRATCH unsigned attrib, *objp, operand;
-    unsigned expr();
-    TOKEN *lex();
-    void do_label(), unlex();
 
     do_label();
     bytes = (attrib = opcod -> attr) & BYTES;
@@ -484,15 +477,12 @@ void normal_op()
     }
 }
 
-unsigned *do_string(s, o)
-char* s;
-unsigned *o;
+unsigned *do_string(char *s, unsigned *o)
 {
     SCRATCH int esc;
     SCRATCH char t;
     SCRATCH char *n, *e;
     SCRATCH unsigned i;
-    int isoct(char c);
 
     esc = FALSE;
     while (*s) {
@@ -554,16 +544,12 @@ unsigned *o;
     return o;
 }
 
-void pseudo_op()
+void pseudo_op(void)
 {
     SCRATCH unsigned *o, u, v;
     SCRATCH SYMBOL *l;
     SCRATCH unsigned i;
     SCRATCH FILE* f;
-    unsigned expr();
-    SYMBOL *find_symbol(), *new_symbol();
-    TOKEN *lex();
-    void do_label(), fatal_error(), hseek(), rseek(), unlex();
 
     o = obj;
     switch (opcod -> valu) {

--- a/a18.h
+++ b/a18.h
@@ -477,4 +477,35 @@ typedef struct {
 
 #define    HEXSIZE        32
 
-extern void error(char code);
+/* from a18eval.c */
+unsigned expr(void);
+int isalph(char c);
+TOKEN *lex(void);
+int newline(void);
+int popc(void);
+void pops(char *s);
+void pushc(char c);
+void trash(void);
+
+/* from a18util.c */
+void error(char code);
+void fatal_error(char *msg);
+OPCODE *find_code(char *nam);
+OPCODE *find_operator(char *nam);
+SYMBOL *find_symbol(char *nam, int label);
+void hclose(void);
+void hopen(char *nam);
+void hputc(unsigned c);
+void hseek(unsigned a);
+void lclose(void);
+void lopen(char *nam);
+void lputs(void);
+SYMBOL *new_symbol(char *nam);
+void rclose(void);
+void ropen(char *nam);
+void rputc(unsigned c);
+void rseek(unsigned a);
+void sclose(void);
+void sopen(char *nam);
+void unlex(void);
+void warning(char *msg);

--- a/a18eval.c
+++ b/a18eval.c
@@ -69,10 +69,15 @@ arithmetic expressions.
 
 #include "a18.h"
 
-int myisalnum(char c);
+/*  Local prototypes:                                                   */
+
+void exp_error(char c);
+unsigned eval(unsigned pre);
 int ishex(char c);
 int isnum(char c);
-int isalph(char c);
+void make_number(unsigned base);
+int myisalnum(char c);
+void unlex(void);
 
 /*  Get access to global mailboxes defined in A68.C:                    */
 
@@ -90,22 +95,18 @@ extern TOKEN token;
 
 static int bad;
 
-unsigned expr()
+unsigned expr(void)
 {
     SCRATCH unsigned u;
-    unsigned eval();
 
     bad = FALSE;
     u = eval(START);
     return bad ? 0 : u;
 }
 
-unsigned eval(pre)
-unsigned pre;
+unsigned eval(unsigned pre)
 {
     register unsigned op, u, v;
-    TOKEN *lex();
-    void exp_error(), unlex();
 
     for (;;) {
         u = op = lex() -> valu;
@@ -234,8 +235,7 @@ unsigned pre;
     }
 }
 
-void exp_error(c)
-char c;
+void exp_error(char c)
 {
     forwd = bad = TRUE;
     error(c);
@@ -250,16 +250,13 @@ char c;
 static int oldt = FALSE;
 static int quote = FALSE;
 
-TOKEN *lex()
+TOKEN *lex(void)
 {
     SCRATCH char c, *p;
     SCRATCH unsigned b;
     SCRATCH OPCODE *o;
     SCRATCH SYMBOL *s;
     SCRATCH int esc;
-    OPCODE *find_operator();
-    SYMBOL *find_symbol();
-    void exp_error(), make_number(), pops(), pushc(), trash();
 
     if (oldt) {
         oldt = FALSE;
@@ -407,12 +404,10 @@ TOKEN *lex()
     return &token;
 }
 
-void make_number(base)
-unsigned base;
+void make_number(unsigned base)
 {
     SCRATCH char *p;
     SCRATCH unsigned d;
-    void exp_error();
 
     token.attr = VAL;
     token.valu = 0;
@@ -428,27 +423,23 @@ unsigned base;
     return;
 }
 
-int isalph(c)
-char c;
+int isalph(char c)
 {
     return (c >= '@' && c <= '~') || c == '!' || c == '#' || c == '$' ||
         c == '%' || c == '&' || c == '.' || c == ':' || c == '?';
 }
 
-int isnum(c)
-char c;
+int isnum(char c)
 {
     return c >= '0' && c <= '9';
 }
 
-int ishex(c)
-char c;
+int ishex(char c)
 {
     return isnum(c) || ((c = toupper(c)) >= 'A' && c <= 'F');
 }
 
-int myisalnum(c)
-char c;
+int myisalnum(char c)
 {
     return isalph(c) || isnum(c);
 }
@@ -456,7 +447,7 @@ char c;
 /*  Push back the current token into the input stream.  One level of    */
 /*  pushback is supported.                                              */
 
-void unlex()
+void unlex(void)
 {
     oldt = TRUE;
     return;
@@ -465,11 +456,8 @@ void unlex()
 /*  Get an alphanumeric string into the string value part of the        */
 /*  current token.  Leading blank space is trashed.                     */
 
-void pops(s)
-char *s;
+void pops(char *s)
 {
-    void pushc(), trash();
-
     trash();
     for (; myisalnum(*s = popc()); ++s);
     pushc(*s);
@@ -479,10 +467,9 @@ char *s;
 
 /*  Trash blank space and push back the character following it.         */
 
-void trash()
+void trash(void)
 {
     SCRATCH char c;
-    void pushc();
 
     while ((c = popc()) == ' ');
     pushc(c);
@@ -498,7 +485,7 @@ void trash()
 static int oldc, eol;
 static char *lptr;
 
-int popc()
+int popc(void)
 {
     SCRATCH int c;
 
@@ -532,8 +519,7 @@ int popc()
 /*  Push character back onto input stream.  Only one level of push-back */
 /*  supported.  \0 cannot be pushed back, but nobody would want to.     */
 
-void pushc(c)
-char c;
+void pushc(char c)
 {
     oldc = c;
     return;
@@ -542,10 +528,8 @@ char c;
 /*  Begin new line of source input.  This routine returns non-zero if   */
 /*  EOF has been reached on the main source file, zero otherwise.       */
 
-int newline()
+int newline(void)
 {
-    void fatal_error();
-
     oldc = '\0';
     lptr = line;
     oldt = eol = FALSE;

--- a/a18eval.c
+++ b/a18eval.c
@@ -71,13 +71,12 @@ arithmetic expressions.
 
 /*  Local prototypes:                                                   */
 
-void exp_error(char c);
-unsigned eval(unsigned pre);
-int ishex(char c);
-int isnum(char c);
-void make_number(unsigned base);
-int myisalnum(char c);
-void unlex(void);
+static void exp_error(char c);
+static unsigned eval(unsigned pre);
+static int ishex(char c);
+static int isnum(char c);
+static void make_number(unsigned base);
+static int myisalnum(char c);
 
 /*  Get access to global mailboxes defined in A68.C:                    */
 
@@ -104,7 +103,7 @@ unsigned expr(void)
     return bad ? 0 : u;
 }
 
-unsigned eval(unsigned pre)
+static unsigned eval(unsigned pre)
 {
     register unsigned op, u, v;
 
@@ -235,7 +234,7 @@ unsigned eval(unsigned pre)
     }
 }
 
-void exp_error(char c)
+static void exp_error(char c)
 {
     forwd = bad = TRUE;
     error(c);
@@ -404,7 +403,7 @@ TOKEN *lex(void)
     return &token;
 }
 
-void make_number(unsigned base)
+static void make_number(unsigned base)
 {
     SCRATCH char *p;
     SCRATCH unsigned d;
@@ -429,17 +428,17 @@ int isalph(char c)
         c == '%' || c == '&' || c == '.' || c == ':' || c == '?';
 }
 
-int isnum(char c)
+static int isnum(char c)
 {
     return c >= '0' && c <= '9';
 }
 
-int ishex(char c)
+static int ishex(char c)
 {
     return isnum(c) || ((c = toupper(c)) >= 'A' && c <= 'F');
 }
 
-int myisalnum(char c)
+static int myisalnum(char c)
 {
     return isalph(c) || isnum(c);
 }

--- a/a18eval.c
+++ b/a18eval.c
@@ -113,7 +113,7 @@ static unsigned eval(unsigned pre)
             case SEP:
                 if (pre != START)
                 unlex();
-
+                /*FALLTHROUGH*/
             case EOL:
                 exp_error('E');
                 printf(" EXPRESSION ERROR 1\n");
@@ -144,7 +144,7 @@ static unsigned eval(unsigned pre)
                         u = low(u);
                         break;
                 }
-
+                /*FALLTHROUGH*/
             case VAL:
             case STR:
                 for (;;) {
@@ -153,6 +153,7 @@ static unsigned eval(unsigned pre)
                         case SEP:
                             if (pre != START)
                                 unlex();
+                            /*FALLTHROUGH*/
                         case EOL:
                             if (pre == LPREN)
                                 exp_error('(');
@@ -304,6 +305,7 @@ TOKEN *lex(void)
             case 'Q':   b = 8; break;
 
             default:    ++p;
+                        /*FALLTHROUGH*/
             case 'D':   b = 10; break;
 
             case 'H':   b = 16; break;

--- a/a18eval.c
+++ b/a18eval.c
@@ -269,7 +269,8 @@ TOKEN *lex()
     if (isalph(c = popc())) {
         pushc(c);
         pops(token.sval);
-        if (o = find_operator(token.sval)) {
+        o = find_operator(token.sval);
+        if (o != NULL) {
             token.attr = o -> attr;
             token.valu = o -> valu;
         }
@@ -288,7 +289,7 @@ TOKEN *lex()
               memmove(token.sval, token.sval + 1, strlen(token.sval));
               make_number(2);
             }
-            else if (s = find_symbol(token.sval, FALSE)) {
+            else if ((s = find_symbol(token.sval, FALSE)) != NULL) {
                 token.valu = s -> valu;
                 if (pass == 2 && s -> attr & FORWD)
                     forwd = TRUE;

--- a/a18util.c
+++ b/a18util.c
@@ -77,13 +77,13 @@ This module contains the following utility packages:
 
 /*  Local prototypes:                                                   */
 
-void check_page(void);
-void list_sym(SYMBOL *sp);
-OPCODE *mybsearch(OPCODE *lo, OPCODE *hi, char *nam);
-void putb(unsigned b);
-void record(unsigned typ);
-int ustrcmp(char *s, char *t);
-void write_shared(SYMBOL *sp);
+static void check_page(void);
+static void list_sym(SYMBOL *sp);
+static OPCODE *mybsearch(OPCODE *lo, OPCODE *hi, char *nam);
+static void putb(unsigned b);
+static void record(unsigned typ);
+static int ustrcmp(char *s, char *t);
+static void write_shared(SYMBOL *sp);
 
 /*  Make sure that MSDOS compilers using the large memory model know    */
 /*  that calloc() returns pointer to char as an MSDOS far pointer is    */
@@ -386,7 +386,7 @@ OPCODE *find_operator(char *nam)
     return mybsearch(oprtbl,oprtbl + (sizeof(oprtbl) / sizeof(OPCODE)),nam);
 }
 
-int ustrcmp(char *s, char *t)
+static int ustrcmp(char *s, char *t)
 {
     SCRATCH int i;
 
@@ -394,7 +394,7 @@ int ustrcmp(char *s, char *t)
     return i;
 }
 
-OPCODE *mybsearch(OPCODE *lo, OPCODE *hi, char *nam)
+static OPCODE *mybsearch(OPCODE *lo, OPCODE *hi, char *nam)
 {
     SCRATCH int i;
     SCRATCH OPCODE *chk;
@@ -540,7 +540,7 @@ void lclose(void)
     return;
 }
 
-void list_sym(SYMBOL *sp)
+static void list_sym(SYMBOL *sp)
 {
     if (sp) {
         list_sym(sp -> left);
@@ -558,7 +558,7 @@ void list_sym(SYMBOL *sp)
     return;
 }
 
-void check_page(void)
+static void check_page(void)
 {
     if (pagelen && !--listleft)
         eject = TRUE;
@@ -682,7 +682,7 @@ void sclose(void)
     return;
 }
 
-void write_shared(SYMBOL *sp)
+static void write_shared(SYMBOL *sp)
 {
     if (sp) {
         write_shared(sp->left);
@@ -765,7 +765,7 @@ void hclose(void)
     return;
 }
 
-void record(unsigned typ)
+static void record(unsigned typ)
 {
     SCRATCH unsigned i;
 
@@ -793,7 +793,7 @@ void record(unsigned typ)
     return;
 }
 
-void putb(unsigned b)
+static void putb(unsigned b)
 {
     static char digit[] = "0123456789ABCDEF";
 

--- a/a18util.c
+++ b/a18util.c
@@ -453,8 +453,6 @@ void lputs()
     SCRATCH int i, j, k;
     SCRATCH unsigned *o;
     void check_page(), fatal_error();
-    char bin[9];
-    bin[8]='\0';
     unsigned char bb=0;
     int didline;
 
@@ -560,7 +558,8 @@ SYMBOL *sp;
     if (sp) {
         list_sym(sp -> left);
         fprintf(list,"%04x  %-10s",sp -> valu,sp -> sname);
-        if (col = ++col % SYMCOLS)
+        col = (col + 1) % SYMCOLS;
+        if (col != 0)
             fprintf(list,"    ");
         else {
             fprintf(list,"\n");


### PR DESCRIPTION
This fixes compile warnings with gcc-13 and clang-12. Most are related to missing prototypes, but two are worth noting:

- The `if (col = ++col % SYMCOLS)` invokes undefined behaviour because it modifies an lvalue more than once between sequence points. Easy fix.
- Some of the missing prototypes where for functions taking `char` parameters, which due to the integer promotions caused mismatches between the assumed prototypes at the call sites (`int`) and the actual definition (`char`). Fixed by having prototypes in scope.